### PR TITLE
Update JSON-RPC spec link to HTTPS

### DIFF
--- a/doc/release-notes/release-notes-0.14.0.md
+++ b/doc/release-notes/release-notes-0.14.0.md
@@ -139,7 +139,7 @@ Support for JSON-RPC Named Arguments
 ------------------------------------
 
 Commands sent over the JSON-RPC interface and through the `bitcoin-cli` binary
-can now use named arguments. This follows the [JSON-RPC specification](http://www.jsonrpc.org/specification)
+can now use named arguments. This follows the [JSON-RPC specification](https://www.jsonrpc.org/specification)
 for passing parameters by-name with an object.
 
 `bitcoin-cli` has been updated to support this by parsing `name=value` arguments


### PR DESCRIPTION
## Summary
- update JSON-RPC spec link in `release-notes-0.14.0.md` to use HTTPS

## Testing
- `cd test/lint/test_runner && cargo run`

------
https://chatgpt.com/codex/tasks/task_e_6859e5df97bc83298dbc1b911d27b0ae