### PR TITLE
Improve string handling in ParseHDKeypath

### DIFF
--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -32,7 +32,7 @@ bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypa
                 return false;
             }
             path |= 0x80000000;
-            item = item.substr(0, item.size() - 1); // Drop the last character which is the hardened tick
+            item.pop_back(); // Drop the last character which is the hardened tick
         }
 
         // Ensure this is only numbers


### PR DESCRIPTION
## Summary
- remove inefficent self-substring call when trimming hardened tick

## Testing
- `cppcheck --enable=warning,style,performance --inline-suppr -q src/util/bip32.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6859e893c2908329b282732434c97ea1